### PR TITLE
Fixing Failing Test Cases

### DIFF
--- a/test/search.js
+++ b/test/search.js
@@ -20,7 +20,7 @@ describe('Duck Duck Go search using basic Puppeteer', function () {
     });
 
     it('should be the correct url', async () => {
-        expect(await page.url()).to.eql('https://google.com/');
+        expect(await page.url()).to.eql('https://duckduckgo.com/');
     });
 
     it('should have the correct page title', async () => {
@@ -28,6 +28,6 @@ describe('Duck Duck Go search using basic Puppeteer', function () {
     });
 
     it('should have the page open', async () => {
-        expect(await page.isClosed()).to.eql(true);
+        expect(await page.isClosed()).to.eql(false);
     });
 });


### PR DESCRIPTION
![Screenshot (1)](https://github.com/CS5704-VT/BrowserAutomation/assets/156931329/8f95bfcf-12d6-4bc0-87b7-321676010313)

The expect tests were written wrong. The first test should be expected to go to duckduckgo. The third test should expect the browser to be closed.

Group Members:
Shreya Aravindan (saravindan)
Justin Turkiewicz (justint417)
Geethika Abhilash(geethika)
Sheril George (sherilhannah)
John Byman (johnbyman)