### PR TITLE
Suggestions for fixing tests

### DIFF
--- a/test/search.js
+++ b/test/search.js
@@ -20,7 +20,7 @@ describe('Duck Duck Go search using basic Puppeteer', function () {
     });
 
     it('should be the correct url', async () => {
-        expect(await page.url()).to.eql('https://google.com/');
+        expect(await page.url()).to.eql('https://duckduckgo.com/');
     });
 
     it('should have the correct page title', async () => {
@@ -28,6 +28,6 @@ describe('Duck Duck Go search using basic Puppeteer', function () {
     });
 
     it('should have the page open', async () => {
-        expect(await page.isClosed()).to.eql(true);
+        expect(await page.isClosed()).to.eql(false);
     });
 });


### PR DESCRIPTION
Yasir Hassan (yasirh):
Changing the expected url from "https://google.com/" to "https://duckduckgo.com/', and the 'should have the page open' value from true to false.

![Screenshot 2024-04-06 185033](https://github.com/CS5704-VT/BrowserAutomation/assets/166188988/87534025-807b-4a82-a6e7-07408988637a)
